### PR TITLE
Disabled retries on the provisioning API call

### DIFF
--- a/create_oracle_arm_instance.ps1
+++ b/create_oracle_arm_instance.ps1
@@ -105,7 +105,7 @@ For ($i = 0; $i -lt $max; $i++)
 
     #request instance creation
     #must be single line, cuz iex / powershell syntax bs
-    $response = & iex "& oci compute instance launch --availability-domain $availDomain $authParams --compartment-id $tenancyId --image-id $imageId  --shape 'VM.Standard.A1.Flex' --shape-config `"{`'ocpus`':$cpus,`'memoryInGBs`':$ram}`"  --subnet-id $subnetId " 2>&1
+    $response = & iex "& oci compute instance launch --no-retry --availability-domain $availDomain $authParams --compartment-id $tenancyId --image-id $imageId  --shape 'VM.Standard.A1.Flex' --shape-config `"{`'ocpus`':$cpus,`'memoryInGBs`':$ram}`"  --subnet-id $subnetId " 2>&1
 
     If($silent -eq 0)
     {


### PR DESCRIPTION
Because this script is already invoking the API repeatedly with the expectation that it will normally fail, the built-in retry causes the remote server to start giving bace Too Many Requests responses pretty fast.  Disabling that ensures that the attempt rate configured in the script is the **actual** rate of invocation.